### PR TITLE
Some Enhancements in Support of Horizontal Splitting and Window Focus Preferences`

### DIFF
--- a/plugin/lotr.vim
+++ b/plugin/lotr.vim
@@ -245,12 +245,22 @@ function! s:CloseWindow() "{{{2
 endfunction
 
 function! s:ZoomWindow() "{{{2
-  if s:is_maximized
-    execute 'vert resize ' . g:lotr_width
-    let s:is_maximized = 0
+  if g:lotr_position == 'top' || g:lotr_position == 'bottom'
+    if s:is_maximized
+      execute 'resize ' . g:lotr_width
+      let s:is_maximized = 0
+    else
+      resize
+      let s:is_maximized = 1
+    endif
   else
-    vert resize
-    let s:is_maximized = 1
+    if s:is_maximized
+      execute 'vert resize ' . g:lotr_width
+      let s:is_maximized = 0
+    else
+      vert resize
+      let s:is_maximized = 1
+    endif
   endif
 endfunction
 

--- a/plugin/lotr.vim
+++ b/plugin/lotr.vim
@@ -68,6 +68,10 @@ if !exists('g:lotr_expand')
   let g:lotr_expand = 0
 endif
 
+if !exists('g:lotr_focus_on_open')
+  let g:lotr_focus_on_open = 0
+endif
+
 let s:autocommands_done        = 0
 let s:source_autocommands_done = 0
 let s:window_expanded          = 0
@@ -157,7 +161,9 @@ function! s:OpenWindow() "{{{2
         \[g:lotr_position] . ' '
   exe 'silent keepalt ' . openpos . g:lotr_winsize . ' split ' . '__LOTR__'
   call s:InitWindow()
-  wincmd p
+  if !g:lotr_focus_on_open
+    wincmd p
+  endif
 endfunction
 
 function! s:InitWindow() "{{{2

--- a/plugin/lotr.vim
+++ b/plugin/lotr.vim
@@ -57,7 +57,11 @@ if !exists('g:lotr_position')
 endif
 
 if !exists('g:lotr_width')
-  let g:lotr_width = 25
+  let g:lotr_width = 0
+endif
+
+if !exists('g:lotr_winsize')
+  let g:lotr_winsize = g:lotr_width ? g:lotr_width : 25
 endif
 
 if !exists('g:lotr_expand')
@@ -143,7 +147,7 @@ function! s:OpenWindow() "{{{2
 
   " Expand the Vim window to accomodate for the LOTR window if requested
   if g:lotr_expand && !s:window_expanded && has('gui_running')
-    let &columns += g:lotr_width + 1
+    let &columns += g:lotr_winsize + 1
     let s:window_expanded = 1
   endif
 
@@ -151,7 +155,7 @@ function! s:OpenWindow() "{{{2
         \ 'top'    : 'topleft',  'left'  : 'topleft vertical',
         \ 'bottom' : 'botright', 'right' : 'botright vertical'}
         \[g:lotr_position] . ' '
-  exe 'silent keepalt ' . openpos . g:lotr_width . ' split ' . '__LOTR__'
+  exe 'silent keepalt ' . openpos . g:lotr_winsize . ' split ' . '__LOTR__'
   call s:InitWindow()
   wincmd p
 endfunction
@@ -238,7 +242,7 @@ function! s:CloseWindow() "{{{2
     endfor
 
     if index(tablist, lotr_bufnr) == -1
-      let &columns -= g:lotr_width + 1
+      let &columns -= g:lotr_winsize + 1
       let s:window_expanded = 0
     endif
   endif
@@ -247,7 +251,7 @@ endfunction
 function! s:ZoomWindow() "{{{2
   if g:lotr_position == 'top' || g:lotr_position == 'bottom'
     if s:is_maximized
-      execute 'resize ' . g:lotr_width
+      execute 'resize ' . g:lotr_winsize
       let s:is_maximized = 0
     else
       resize
@@ -255,7 +259,7 @@ function! s:ZoomWindow() "{{{2
     endif
   else
     if s:is_maximized
-      execute 'vert resize ' . g:lotr_width
+      execute 'vert resize ' . g:lotr_winsize
       let s:is_maximized = 0
     else
       vert resize


### PR DESCRIPTION
- Window zooming works in either vertical or horizontal axis, depending on `g:lotr_position`
- Variable `g:lotr_width` still supported, but primary variable is now `g:lotr_winsize`, to account for bi-directionality
- I think return focus to previous window was a deliberate design choice, but I have added the option to have focus remain on LOTR
- TODO: expand still assumes Vim has expanded horizontally (i.e., LOTR split was created left/right by adding columns); need to allow it to work vertically (i.e., LOTR split was created top/bottom by adding rows);
